### PR TITLE
Responsive sidenotes for footnotes

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -88,7 +88,9 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.setLibrary(
     "md",
-    markdownIt({ html: true }).use(markdownItAnchor)
+    markdownIt({ html: true })
+      .use(markdownItAnchor)
+      .use(require("markdown-it-footnote"))
   );
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "eleventy-plugin-toc": "^1.1.5",
-        "markdown-it-anchor": "^9.2.0"
+        "markdown-it-anchor": "^9.2.0",
+        "markdown-it-footnote": "^4.0.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
@@ -1520,6 +1521,12 @@
         "@types/markdown-it": "*",
         "markdown-it": "*"
       }
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "cheerio": "^1.2.0",
         "eleventy-plugin-toc": "^1.1.5",
         "markdown-it-anchor": "^9.2.0",
         "markdown-it-footnote": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "markdown-it": "^14.1.0"
   },
   "dependencies": {
+    "cheerio": "^1.2.0",
     "eleventy-plugin-toc": "^1.1.5",
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-footnote": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "start": "eleventy --serve",
     "build": "eleventy",
-    "serve": "eleventy --serve"
+    "serve": "eleventy --serve",
+    "check-grammar": "node scripts/check-grammar.js",
+    "generate-social-drafts": "node scripts/generate-social-drafts.js",
+    "generate-newsletter-variant": "node scripts/generate-newsletter-variant.js"
   },
   "keywords": [
     "eleventy",
@@ -22,6 +25,7 @@
   },
   "dependencies": {
     "eleventy-plugin-toc": "^1.1.5",
-    "markdown-it-anchor": "^9.2.0"
+    "markdown-it-anchor": "^9.2.0",
+    "markdown-it-footnote": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "scripts": {
     "start": "eleventy --serve",
     "build": "eleventy",
-    "serve": "eleventy --serve",
-    "check-grammar": "node scripts/check-grammar.js",
-    "generate-social-drafts": "node scripts/generate-social-drafts.js",
-    "generate-newsletter-variant": "node scripts/generate-newsletter-variant.js"
+    "serve": "eleventy --serve"
   },
   "keywords": [
     "eleventy",

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -11,7 +11,10 @@ layout: layouts/base.njk
     {% if description %}
     <p class="post-summary">{{ description }}</p>
     {% endif %}
-    <p class="byline">{{ date | formatDate('MMMM d, yyyy') }}</p>
+    <p class="byline">
+      {{ date | formatDate('MMMM d, yyyy') }}
+      <button class="sidenote-toggle" aria-label="Toggle sidenotes" onclick="var a=this.closest('.prose');a.classList.toggle('notes-hidden');this.textContent=a.classList.contains('notes-hidden')?'Show notes':'Hide notes'">Hide notes</button>
+    </p>
   </header>
   {% if tocContent %}
   <details class="toc">

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -11,10 +11,7 @@ layout: layouts/base.njk
     {% if description %}
     <p class="post-summary">{{ description }}</p>
     {% endif %}
-    <p class="byline">
-      {{ date | formatDate('MMMM d, yyyy') }}
-      <button class="sidenote-toggle" aria-label="Toggle sidenotes" onclick="var a=this.closest('.prose');a.classList.toggle('notes-hidden');this.textContent=a.classList.contains('notes-hidden')?'Show notes':'Hide notes'">Hide notes</button>
-    </p>
+    <p class="byline">{{ date | formatDate('MMMM d, yyyy') }}</p>
   </header>
   {% if tocContent %}
   <details class="toc">

--- a/src/assets/css/typography.css
+++ b/src/assets/css/typography.css
@@ -32,7 +32,7 @@
 /* Drop cap for first paragraph of content - spans 2 lines */
 .prose header + p::first-letter,
 .prose details + p::first-letter,
-.prose aside + p::first-letter {
+.prose aside:not(.sidenote) + p::first-letter {
   font-family: var(--font-heading);
   font-size: 3.25em;
   line-height: 0.9;
@@ -217,15 +217,12 @@
 }
 
 @media (min-width: 960px) {
-  .prose.has-sidenotes {
-    position: relative;
-  }
   .sidenote {
-    position: absolute;
-    right: 0;
-    transform: translateX(calc(100% + var(--space-xl)));
+    float: right;
+    clear: right;
     width: 200px;
-    margin: 0;
+    margin-right: calc(-200px - var(--space-xl));
+    margin-bottom: var(--space-md);
     padding: 0 0 0 var(--space-md);
   }
   .prose .footnote-ref a {

--- a/src/assets/css/typography.css
+++ b/src/assets/css/typography.css
@@ -226,7 +226,6 @@
     transform: translateX(calc(100% + var(--space-xl)));
     width: 200px;
     margin: 0;
-    border-left: 2px solid var(--color-border);
     padding: 0 0 0 var(--space-md);
   }
   .prose .footnote-ref a {
@@ -237,12 +236,6 @@
 /* Toggle: hide/show sidenotes */
 .sidenote-toggle {
   display: none;
-}
-.prose.has-sidenotes ~ .sidenote-toggle,
-.prose.has-sidenotes .sidenote-toggle {
-  display: inline-block;
-}
-.sidenote-toggle {
   background: none;
   border: 1px solid var(--color-border);
   border-radius: 4px;
@@ -252,6 +245,9 @@
   cursor: pointer;
   font-family: var(--font-base);
   transition: color 0.15s, border-color 0.15s;
+}
+.prose.has-sidenotes .sidenote-toggle {
+  display: inline-block;
 }
 .sidenote-toggle:hover {
   color: var(--color-fg);

--- a/src/assets/css/typography.css
+++ b/src/assets/css/typography.css
@@ -185,3 +185,50 @@
 .card__date { margin-bottom: var(--space-xs); }
 .card__tags a { color: var(--color-link); text-decoration: none; }
 .card__tags a:hover { text-decoration: underline; }
+
+/* Footnotes (markdown-it-footnote) */
+.prose .footnote-ref {
+  font-size: var(--type-scale-xs);
+  font-weight: 600;
+  margin-left: 0.15em;
+}
+.prose .footnote-ref a {
+  text-decoration: none;
+  color: var(--color-muted);
+}
+.prose .footnote-ref a:hover {
+  color: var(--color-link);
+}
+.prose .footnotes {
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--type-scale-sm);
+  color: var(--color-muted);
+}
+.prose .footnotes hr {
+  display: none;
+}
+.prose .footnotes ol {
+  margin: 0;
+  padding-left: var(--space-lg);
+}
+.prose .footnotes li {
+  margin-bottom: var(--space-sm);
+}
+.prose .footnotes li p {
+  margin: 0;
+}
+.prose .footnotes a {
+  color: var(--color-link);
+}
+.prose .footnotes a:hover {
+  color: var(--color-link-hover);
+}
+.prose .footnotes .footnote-backref {
+  text-decoration: none;
+  margin-left: 0.2em;
+}
+.prose .footnotes .footnote-backref:hover {
+  text-decoration: underline;
+}

--- a/src/assets/css/typography.css
+++ b/src/assets/css/typography.css
@@ -186,7 +186,7 @@
 .card__tags a { color: var(--color-link); text-decoration: none; }
 .card__tags a:hover { text-decoration: underline; }
 
-/* Footnotes (markdown-it-footnote) */
+/* Footnote refs (inline superscripts) */
 .prose .footnote-ref {
   font-size: var(--type-scale-xs);
   font-weight: 600;
@@ -199,6 +199,73 @@
 .prose .footnote-ref a:hover {
   color: var(--color-link);
 }
+
+/* Sidenotes (build-time transformed from footnotes) */
+.sidenote {
+  font-size: var(--type-scale-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-muted);
+  border-left: 2px solid var(--color-border);
+  padding: var(--space-sm) 0 var(--space-sm) var(--space-md);
+  margin: var(--space-sm) 0 var(--space-md);
+}
+.sidenote a {
+  color: var(--color-link);
+}
+.sidenote a:hover {
+  color: var(--color-link-hover);
+}
+
+@media (min-width: 960px) {
+  .prose.has-sidenotes {
+    position: relative;
+  }
+  .sidenote {
+    position: absolute;
+    right: 0;
+    transform: translateX(calc(100% + var(--space-xl)));
+    width: 200px;
+    margin: 0;
+    border-left: 2px solid var(--color-border);
+    padding: 0 0 0 var(--space-md);
+  }
+  .prose .footnote-ref a {
+    color: var(--color-link);
+  }
+}
+
+/* Toggle: hide/show sidenotes */
+.sidenote-toggle {
+  display: none;
+}
+.prose.has-sidenotes ~ .sidenote-toggle,
+.prose.has-sidenotes .sidenote-toggle {
+  display: inline-block;
+}
+.sidenote-toggle {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--type-scale-xs);
+  color: var(--color-muted);
+  cursor: pointer;
+  font-family: var(--font-base);
+  transition: color 0.15s, border-color 0.15s;
+}
+.sidenote-toggle:hover {
+  color: var(--color-fg);
+  border-color: var(--color-fg);
+}
+
+.prose.notes-hidden .sidenote {
+  display: none;
+}
+.prose.notes-hidden .footnote-ref {
+  display: none;
+}
+
+/* Fallback: if transform didn't run, keep footnotes at bottom */
 .prose .footnotes {
   margin-top: var(--space-2xl);
   padding-top: var(--space-lg);
@@ -206,29 +273,11 @@
   font-size: var(--type-scale-sm);
   color: var(--color-muted);
 }
-.prose .footnotes hr {
-  display: none;
-}
-.prose .footnotes ol {
-  margin: 0;
-  padding-left: var(--space-lg);
-}
-.prose .footnotes li {
-  margin-bottom: var(--space-sm);
-}
-.prose .footnotes li p {
-  margin: 0;
-}
-.prose .footnotes a {
-  color: var(--color-link);
-}
-.prose .footnotes a:hover {
-  color: var(--color-link-hover);
-}
-.prose .footnotes .footnote-backref {
-  text-decoration: none;
-  margin-left: 0.2em;
-}
-.prose .footnotes .footnote-backref:hover {
-  text-decoration: underline;
-}
+.prose hr.footnotes-sep { display: none; }
+.prose .footnotes ol { margin: 0; padding-left: var(--space-lg); }
+.prose .footnotes li { margin-bottom: var(--space-sm); }
+.prose .footnotes li p { margin: 0; }
+.prose .footnotes a { color: var(--color-link); }
+.prose .footnotes a:hover { color: var(--color-link-hover); }
+.prose .footnotes .footnote-backref { text-decoration: none; margin-left: 0.2em; }
+.prose .footnotes .footnote-backref:hover { text-decoration: underline; }

--- a/src/posts/2026-02-10-i-have-no-idea-what-im-doing.md
+++ b/src/posts/2026-02-10-i-have-no-idea-what-im-doing.md
@@ -13,7 +13,7 @@ draft: true
 
 {% figure "/assets/images/no-idea-what-im-doing.png", "Dog at computer with text: I have no idea what I'm doing" %}
 
-In April of 2024, I was sitting with Patrick Fulton, my wife Jamie, and Noelle Lansford in the Palladium Theater in St. Petersburg, Florida. We were on a break between sessions at the Front End Design Conf. I think [Ben Callahan](https://bencallahan.com/the-question) had just finished[^ben], and he was standing chatting with us. I don't really remember exactly what we said; it was a while ago, but I remember the conversation turning to Design System Engineering—specifically, the gap between design resources and engineering resources. I wanted to do something about it.
+In April of 2024, I was sitting with Patrick Fulton, my wife Jamie, and Noelle Lansford[^noelle] in the Palladium Theater in St. Petersburg, Florida. We were on a break between sessions at the Front End Design Conf. I think [Ben Callahan](https://bencallahan.com/the-question) had just finished[^ben], and he was standing chatting with us. I don't really remember exactly what we said; it was a while ago, but I remember the conversation turning to Design System Engineering—specifically, the gap between design resources and engineering resources. I wanted to do something about it.
 
 In 2022, my wife and I were working on our MBA online from Quantic, and for our capstone we put together a proposal for building a course for Design System Engineering and how we could make it something that might be able to make some money, but also get some of the ideas and experience I've had working on [Spectrum](https://spectrum.adobe.com/), Adobe's design system, out of my head and share it with others.
 
@@ -43,5 +43,6 @@ I'm committed to filling that gap. Resources, frameworks, eventually a course. B
 
 I'm figuring this out as I go, but I'm moving forward. Come build it with me.
 
-[^ben]: *The Question* is an excellent talk—well worth watching if you get the chance.
+[^ben]: [*The Question*](https://bencallahan.com/the-question) is a weekly collaborative learning discussion for anyone seriously interested in design systems—well worth checking out.
 [^mathieu]: Mathieu is now Head of Design at [Photoroom](https://photoroom.com). You can find him on [LinkedIn](https://www.linkedin.com/in/mathieubadimon/).
+[^noelle]: Noelle is Founder & CEO of [Shep](http://noellelansford.com), a design system consultancy, and an Into Design Systems chapter organizer in Columbus, Ohio.

--- a/src/posts/2026-02-10-i-have-no-idea-what-im-doing.md
+++ b/src/posts/2026-02-10-i-have-no-idea-what-im-doing.md
@@ -13,13 +13,13 @@ draft: true
 
 {% figure "/assets/images/no-idea-what-im-doing.png", "Dog at computer with text: I have no idea what I'm doing" %}
 
-In April of 2024, I was sitting with Patrick Fulton, my wife Jamie, and Noelle Lansford in the Palladium Theater in St. Petersburg, Florida. We were on a break between sessions at the Front End Design Conf. I think [Ben Callahan](https://bencallahan.com/the-question) had just finished, and he was standing chatting with us. I don't really remember exactly what we said; it was a while ago, but I remember the conversation turning to Design System Engineering—specifically, the gap between design resources and engineering resources. I wanted to do something about it.
+In April of 2024, I was sitting with Patrick Fulton, my wife Jamie, and Noelle Lansford in the Palladium Theater in St. Petersburg, Florida. We were on a break between sessions at the Front End Design Conf. I think [Ben Callahan](https://bencallahan.com/the-question) had just finished[^ben], and he was standing chatting with us. I don't really remember exactly what we said; it was a while ago, but I remember the conversation turning to Design System Engineering—specifically, the gap between design resources and engineering resources. I wanted to do something about it.
 
 In 2022, my wife and I were working on our MBA online from Quantic, and for our capstone we put together a proposal for building a course for Design System Engineering and how we could make it something that might be able to make some money, but also get some of the ideas and experience I've had working on [Spectrum](https://spectrum.adobe.com/), Adobe's design system, out of my head and share it with others.
 
 Further back in 2020, I was finishing up a Master's degree, Digital Media Design from Harvard Extension school, and I was using my capstone project as an excuse to apply the andragogy skills I had been sharpening to a Design Systems Engineering course or workshop that I could use to teach front-end engineers how to build a design system from scratch.
 
-All the way back in 2016, I was working as a front-end design engineer on PhoneGap at Adobe. I was working with some really smart developers, and we were kicking around the idea of building a default web ui kit for new PhoneGap developers to use as a starting point for building new apps. I wanted it to leverage Adobe's strong design branding, and someone mentioned I should chat with Mathieu Badimon, who was working on ideas from the design side. This eventually led to me working full-time on [Spectrum](https://spectrum.adobe.com/), Adobe's Design System, and returning to the Adobe Design Team.
+All the way back in 2016, I was working as a front-end design engineer on PhoneGap at Adobe. I was working with some really smart developers, and we were kicking around the idea of building a default web ui kit for new PhoneGap developers to use as a starting point for building new apps. I wanted it to leverage Adobe's strong design branding, and someone mentioned I should chat with Mathieu Badimon[^mathieu], who was working on ideas from the design side. This eventually led to me working full-time on [Spectrum](https://spectrum.adobe.com/), Adobe's Design System, and returning to the Adobe Design Team.
 
 Last stop on the time machine tour: in 2011, I was interviewed and hired by Ethan Eismann as a Senior Experience Designer to work on the default styling for Adobe Flex 4. It was my first experience building what I would later consider to be a design system. It was intended to be a generic starting set of components for designers and engineers building applications with Flex 4's new Spark architecture. Spark used Flex 4's new skinning engine, which allowed for full decoupling of logic from styling and appearance. It was a super fun, strongly typed architecture, and I loved being a Designer working on developer tools in a framework I knew very well.
 
@@ -42,3 +42,6 @@ I'm committed to filling that gap. Resources, frameworks, eventually a course. B
 [Subscribe to the newsletter](https://pages.designsystems.engineer/), find me on [LinkedIn](https://www.linkedin.com/in/garthdb/) or [Bluesky](https://bsky.app/profile/garthdb.com), or reach out however you prefer.
 
 I'm figuring this out as I go, but I'm moving forward. Come build it with me.
+
+[^ben]: *The Question* is an excellent talk—well worth watching if you get the chance.
+[^mathieu]: Mathieu is now Head of Design at [Photoroom](https://photoroom.com). You can find him on [LinkedIn](https://www.linkedin.com/in/mathieubadimon/).


### PR DESCRIPTION
## Summary
- Adds a build-time Eleventy transform (cheerio) that restructures markdown-it-footnote output into `<aside class="sidenote">` elements placed next to each referencing paragraph — no client-side JS for layout.
- On wide viewports (960px+), sidenotes appear in the right margin; on narrow screens they display as bordered blocks between paragraphs. Falls back to standard bottom-of-post footnotes if the transform doesn't run.
- Adds a "Hide notes" / "Show notes" toggle button in the post byline that hides both sidenotes and inline `[1]`, `[2]` refs.

## Test plan
- [ ] Verify sidenotes appear in the right margin on wide viewports (960px+)
- [ ] Verify sidenotes fall back to inline blocks on narrow viewports (<960px)
- [ ] Click "Hide notes" — sidenotes and `[1]`/`[2]` refs should disappear
- [ ] Click "Show notes" — sidenotes and refs reappear
- [ ] Verify posts without footnotes don't show the toggle button
- [ ] Verify the build completes without errors (`npm run build`)


Made with [Cursor](https://cursor.com)